### PR TITLE
Added a network adapter–based interface address configuration module.

### DIFF
--- a/src/main/kotlin/com/burpmcp/ultra/core/BurpMcpUltraExtension.kt
+++ b/src/main/kotlin/com/burpmcp/ultra/core/BurpMcpUltraExtension.kt
@@ -36,6 +36,9 @@ class BurpMcpUltraExtension : BurpExtension {
         val prefs = api.persistence().preferences()
         val authToken = prefs.getString("mcp_auth_token")
             ?: SecurityConfig.generateToken().also { prefs.setString("mcp_auth_token", it) }
+        val bindHost = System.getProperty("burpmcp.bindHost")?.trim()?.ifEmpty { null }
+            ?: prefs.getString("mcp_bind_host")?.trim()?.ifEmpty { null }
+            ?: "127.0.0.1"
 
         // Create all bridge instances via factory
         val bridges = BridgeFactory.createAll(api, eventBus, stateManager)
@@ -46,20 +49,21 @@ class BurpMcpUltraExtension : BurpExtension {
             eventBus = eventBus,
             stateManager = stateManager,
             authToken = authToken,
+            bindHost = bindHost,
             ssePort = 9876,
             httpPort = 9877,
             logging = api.logging()
         )
         serverManager.start()
 
-        dashboardServer = DashboardServer(bridges, eventBus, stateManager, authToken, 9878, api.logging())
+        dashboardServer = DashboardServer(bridges, eventBus, stateManager, authToken, bindHost, 9878, api.logging())
         dashboardServer.start()
 
         // Register Burp Suite event handlers for proxy, scanner, scope, websocket, and HTTP traffic
         registerBurpHandlers(bridges)
 
         // Initialize and register the UI tab
-        uiTab = BurpMcpUltraTab(api, serverManager, eventBus, stateManager, bridges, authToken)
+        uiTab = BurpMcpUltraTab(api, serverManager, eventBus, stateManager, bridges, authToken, bindHost)
         api.userInterface().registerSuiteTab("BurpMCP-Ultra", uiTab.getComponent())
 
         // Register unload handler for clean shutdown
@@ -77,11 +81,11 @@ class BurpMcpUltraExtension : BurpExtension {
         // output log, so one channel covers both surfaces.
         val (toolCount, resourceCount) = serverManager.registeredCounts()
         uiTab.log("INFO", "System", "BurpMCP-Ultra v${BuildInfo.VERSION} started")
-        uiTab.log("INFO", "System", "MCP SSE (primary):   http://127.0.0.1:9876/  (root path '/', bearer token required)")
-        uiTab.log("INFO", "System", "MCP SSE (secondary): http://127.0.0.1:9877/")
-        uiTab.log("INFO", "System", "Dashboard:                 http://127.0.0.1:9878")
+        uiTab.log("INFO", "System", "MCP SSE (primary):   http://$bindHost:9876/  (root path '/', bearer token required)")
+        uiTab.log("INFO", "System", "MCP SSE (secondary): http://$bindHost:9877/")
+        uiTab.log("INFO", "System", "Dashboard:                 http://$bindHost:9878")
         uiTab.log("INFO", "System", "Tools: $toolCount  |  MCP Resources: $resourceCount")
-        api.logging().raiseInfoEvent("BurpMCP-Ultra v${BuildInfo.VERSION} started (SSE 9876/9877, dashboard 9878)")
+        api.logging().raiseInfoEvent("BurpMCP-Ultra v${BuildInfo.VERSION} started on $bindHost (SSE 9876/9877, dashboard 9878)")
 
         // Do NOT log the auth token. uiTab.log() also writes to Burp's shared output
         // log, so logging the token would leak it into saved project files / screenshots.

--- a/src/main/kotlin/com/burpmcp/ultra/core/ConnectionInfo.kt
+++ b/src/main/kotlin/com/burpmcp/ultra/core/ConnectionInfo.kt
@@ -18,11 +18,15 @@ object ConnectionInfo {
     const val TOKEN_PLACEHOLDER = "PASTE_TOKEN_FROM_SERVER_TAB"
 
     /** The MCP SSE endpoint URL for [port] — the ROOT path `/`, never `/sse`. */
-    fun sseUrl(port: Int): String = "http://127.0.0.1:$port/"
+    fun sseUrl(port: Int, host: String = "127.0.0.1"): String = "http://$host:$port/"
 
     val primarySseUrl: String get() = sseUrl(PRIMARY_PORT)
     val secondarySseUrl: String get() = sseUrl(SECONDARY_PORT)
-    val dashboardUrl: String get() = "http://127.0.0.1:$DASHBOARD_PORT"
+    val dashboardUrl: String get() = dashboardUrlForHost()
+
+    fun primarySseUrlForHost(host: String): String = sseUrl(PRIMARY_PORT, host)
+    fun secondarySseUrlForHost(host: String): String = sseUrl(SECONDARY_PORT, host)
+    fun dashboardUrlForHost(host: String = "127.0.0.1"): String = "http://$host:$DASHBOARD_PORT"
 
     /**
      * A ready-to-paste MCP client config. Pass the real [token] ONLY for same-process
@@ -30,8 +34,8 @@ object ConnectionInfo {
      * token is not embedded in HTML — the user then fills [TOKEN_PLACEHOLDER] from the
      * Server tab (this preserves the dashboard's HttpOnly-cookie token confidentiality).
      */
-    fun clientConfigJson(token: String?, port: Int = PRIMARY_PORT): String {
+    fun clientConfigJson(token: String?, port: Int = PRIMARY_PORT, host: String = "127.0.0.1"): String {
         val bearer = token ?: TOKEN_PLACEHOLDER
-        return """{"mcpServers":{"burp":{"type":"sse","url":"${sseUrl(port)}","headers":{"Authorization":"Bearer $bearer"}}}}"""
+        return """{"mcpServers":{"burp":{"type":"sse","url":"${sseUrl(port, host)}","headers":{"Authorization":"Bearer $bearer"}}}}"""
     }
 }

--- a/src/main/kotlin/com/burpmcp/ultra/transport/DashboardServer.kt
+++ b/src/main/kotlin/com/burpmcp/ultra/transport/DashboardServer.kt
@@ -23,6 +23,7 @@ class DashboardServer(
     private val eventBus: EventBus,
     private val stateManager: StateManager,
     private val authToken: String,
+    private val bindHost: String = "127.0.0.1",
     private val port: Int = 9878,
     private val logging: Logging
 ) {
@@ -33,11 +34,16 @@ class DashboardServer(
     fun start() {
         scope.launch {
             try {
-                server = embeddedServer(CIO, port = port, host = "127.0.0.1") {
+                server = embeddedServer(CIO, port = port, host = bindHost) {
                     // Host-header allowlist + locked CORS + token auth. "/" is
                     // token-exempt (so the browser can load the page); the page
                     // then injects the token for its own /api + /events calls.
-                    installLocalhostSecurity(authToken, listOf(port), tokenExemptPaths = setOf("/"))
+                    installLocalhostSecurity(
+                        authToken,
+                        listOf(port),
+                        allowedSecurityHosts(),
+                        tokenExemptPaths = setOf("/")
+                    )
                     install(SSE)
 
                     routing {
@@ -159,7 +165,7 @@ class DashboardServer(
                     }
                 }.also { it.start(wait = false) }
 
-                logging.logToOutput("BurpMCP-Ultra: Dashboard server started on http://127.0.0.1:$port")
+                logging.logToOutput("BurpMCP-Ultra: Dashboard server started on http://$bindHost:$port")
             } catch (e: Exception) {
                 logging.logToError("BurpMCP-Ultra: Dashboard server failed: ${e.message}")
             }
@@ -173,7 +179,15 @@ class DashboardServer(
 
     private fun getDashboardHtml(): String {
         return DASHBOARD_HTML
+            .replace("__PRIMARY_SSE_URL__", ConnectionInfo.primarySseUrlForHost(bindHost))
+            .replace("__SECONDARY_SSE_URL__", ConnectionInfo.secondarySseUrlForHost(bindHost))
+            .replace("__DASHBOARD_URL__", ConnectionInfo.dashboardUrlForHost(bindHost))
+            .replace("__DASHBOARD_PROXY_HISTORY_URL__", "${ConnectionInfo.dashboardUrlForHost(bindHost)}/api/proxy/recent?limit=50")
+            .replace("__MCP_CLIENT_CONFIG__", ConnectionInfo.clientConfigJson(null, host = bindHost))
     }
+
+    private fun allowedSecurityHosts(): List<String> =
+        listOf(bindHost, "127.0.0.1", "localhost").distinct()
 
     companion object {
         val DASHBOARD_HTML = """
@@ -435,11 +449,11 @@ body{font-family:var(--font);background:var(--bg-primary);color:var(--text-prima
 <!-- Connections Tab -->
 <div class="tab-panel" id="panel-connections">
     <div class="conn-grid">
-        <div class="conn-card"><h4>Primary MCP SSE (root path, token required)</h4><div class="url">${ConnectionInfo.primarySseUrl}</div></div>
-        <div class="conn-card"><h4>Secondary MCP SSE (root path)</h4><div class="url">${ConnectionInfo.secondarySseUrl}</div></div>
-        <div class="conn-card"><h4>Dashboard</h4><div class="url">${ConnectionInfo.dashboardUrl}</div></div>
-        <div class="conn-card"><h4>Dashboard API - Proxy History</h4><div class="url">${ConnectionInfo.dashboardUrl}/api/proxy/recent?limit=50</div></div>
-        <div class="conn-card"><h4>MCP Client Config — replace token from the Server tab</h4><div class="url" style="font-size:11px;">${ConnectionInfo.clientConfigJson(null)}</div></div>
+        <div class="conn-card"><h4>Primary MCP SSE (root path, token required)</h4><div class="url">__PRIMARY_SSE_URL__</div></div>
+        <div class="conn-card"><h4>Secondary MCP SSE (root path)</h4><div class="url">__SECONDARY_SSE_URL__</div></div>
+        <div class="conn-card"><h4>Dashboard</h4><div class="url">__DASHBOARD_URL__</div></div>
+        <div class="conn-card"><h4>Dashboard API - Proxy History</h4><div class="url">__DASHBOARD_PROXY_HISTORY_URL__</div></div>
+        <div class="conn-card"><h4>MCP Client Config — replace token from the Server tab</h4><div class="url" style="font-size:11px;">__MCP_CLIENT_CONFIG__</div></div>
     </div>
 </div>
 

--- a/src/main/kotlin/com/burpmcp/ultra/transport/McpServerManager.kt
+++ b/src/main/kotlin/com/burpmcp/ultra/transport/McpServerManager.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.*
  * @param bridges All bridge instances for tool/resource registration.
  * @param eventBus Shared event bus for event-related tools/resources.
  * @param stateManager Shared state for stateful tools.
+ * @param bindHost Interface address to bind the transport servers to.
  * @param ssePort TCP port for the primary SSE transport (default 9876).
  * @param httpPort TCP port for the secondary SSE transport (default 9877).
  * @param logging Burp Suite logging API for startup/error messages.
@@ -43,6 +44,7 @@ class McpServerManager(
     private val eventBus: EventBus,
     private val stateManager: StateManager,
     private val authToken: String,
+    private val bindHost: String = "127.0.0.1",
     private val ssePort: Int = 9876,
     private val httpPort: Int = 9877,
     private val logging: Logging
@@ -133,34 +135,34 @@ class McpServerManager(
     ) {
         scope.launch {
             try {
-                val server = embeddedServer(CIO, port = port, host = "127.0.0.1") {
-                    installLocalhostSecurity(authToken, listOf(port))
+                val server = embeddedServer(CIO, port = port, host = bindHost) {
+                    installLocalhostSecurity(authToken, listOf(port), allowedSecurityHosts())
                     mcp(serverFactory())
                 }
                 server.start(wait = false)
                 assign(server)
 
                 if (verifyListening(port)) {
-                    logging.logToOutput("BurpMCP-Ultra: $label transport listening on http://127.0.0.1:$port (MCP SSE endpoint is the root path '/', not '/sse')")
+                    logging.logToOutput("BurpMCP-Ultra: $label transport listening on http://$bindHost:$port (MCP SSE endpoint is the root path '/', not '/sse')")
                 } else {
                     logging.logToError(
-                        "BurpMCP-Ultra: $label transport reported start() but port $port is NOT listening. " +
+                        "BurpMCP-Ultra: $label transport reported start() but $bindHost:$port is NOT listening. " +
                             "This is the GitHub issue #2/#3 symptom — almost always a JAR built with Java 22+ " +
                             "(Kotlin/Ktor/MCP-SDK incompatibility). Rebuild with a JDK 17-21 (NOT Burp's bundled Java 25)."
                     )
                 }
             } catch (e: Exception) {
-                logging.logToError("BurpMCP-Ultra: Failed to start $label transport on port $port: ${e.message}")
+                logging.logToError("BurpMCP-Ultra: Failed to start $label transport on $bindHost:$port: ${e.message}")
                 logging.logToError("BurpMCP-Ultra: Stack trace: ${e.stackTraceToString()}")
             }
         }
     }
 
-    /** Probes 127.0.0.1:[port] for up to ~3s to confirm the engine actually bound the socket. */
+    /** Probes [bindHost]:[port] for up to ~3s to confirm the engine actually bound the socket. */
     private suspend fun verifyListening(port: Int): Boolean {
         repeat(15) {
             try {
-                java.net.Socket().use { it.connect(java.net.InetSocketAddress("127.0.0.1", port), 200) }
+                java.net.Socket().use { it.connect(java.net.InetSocketAddress(bindHost, port), 200) }
                 return true
             } catch (_: Exception) {
                 kotlinx.coroutines.delay(200)
@@ -168,6 +170,9 @@ class McpServerManager(
         }
         return false
     }
+
+    private fun allowedSecurityHosts(): List<String> =
+        listOf(bindHost, "127.0.0.1", "localhost").distinct()
 
     /**
      * Gracefully stops both transport servers and cancels the coroutine scope.

--- a/src/main/kotlin/com/burpmcp/ultra/transport/SecurityConfig.kt
+++ b/src/main/kotlin/com/burpmcp/ultra/transport/SecurityConfig.kt
@@ -50,12 +50,11 @@ object SecurityConfig {
 fun Application.installLocalhostSecurity(
     token: String,
     ports: List<Int>,
+    hosts: List<String> = listOf("127.0.0.1", "localhost"),
     tokenExemptPaths: Set<String> = emptySet()
 ) {
-    val allowedHosts = ports.flatMap { listOf("127.0.0.1:$it", "localhost:$it") }.toSet()
-    val allowedOrigins = ports.flatMap {
-        listOf("http://127.0.0.1:$it", "http://localhost:$it")
-    }.toSet()
+    val allowedHosts = ports.flatMap { port -> hosts.map { host -> "$host:$port" } }.toSet()
+    val allowedOrigins = ports.flatMap { port -> hosts.map { host -> "http://$host:$port" } }.toSet()
 
     install(CORS) {
         allowMethod(HttpMethod.Options)
@@ -65,10 +64,11 @@ fun Application.installLocalhostSecurity(
         allowHeader(HttpHeaders.Authorization)
         allowHeader(HttpHeaders.ContentType)
         allowNonSimpleContentTypes = true
-        // Only loopback origins are ever permitted — never anyHost().
+        // Only explicitly configured origins are ever permitted — never anyHost().
         ports.forEach { p ->
-            allowHost("127.0.0.1:$p", schemes = listOf("http"))
-            allowHost("localhost:$p", schemes = listOf("http"))
+            hosts.forEach { host ->
+                allowHost("$host:$p", schemes = listOf("http"))
+            }
         }
     }
 

--- a/src/main/kotlin/com/burpmcp/ultra/ui/BurpMcpUltraTab.kt
+++ b/src/main/kotlin/com/burpmcp/ultra/ui/BurpMcpUltraTab.kt
@@ -47,7 +47,8 @@ class BurpMcpUltraTab(
     private val eventBus: EventBus,
     private val stateManager: StateManager,
     private val bridges: BridgeFactory.Bridges,
-    private val authToken: String
+    private val authToken: String,
+    private val bindHost: String
 ) {
     companion object {
         const val MAX_TABLE_ROWS = 2000
@@ -843,46 +844,76 @@ class BurpMcpUltraTab(
         content.add(JLabel("Connection Information").apply { font = font.deriveFont(Font.BOLD, 14f) }, gbc)
         gbc.gridwidth = 1
 
-        addRow(1, "MCP SSE (root /):", JLabel(ConnectionInfo.primarySseUrl))
-        addRow(2, "SSE (secondary):", JLabel(ConnectionInfo.secondarySseUrl))
-        addRow(3, "Dashboard:", JLabel(ConnectionInfo.dashboardUrl))
+        addRow(1, "MCP SSE (root /):", JLabel(ConnectionInfo.primarySseUrlForHost(bindHost)))
+        addRow(2, "SSE (secondary):", JLabel(ConnectionInfo.secondarySseUrlForHost(bindHost)))
+        addRow(3, "Dashboard:", JLabel(ConnectionInfo.dashboardUrlForHost(bindHost)))
 
         gbc.gridy = 4; gbc.gridx = 0; gbc.gridwidth = 2
         content.add(JSeparator(), gbc); gbc.gridwidth = 1
 
-        // MCP config
+        // Bind host config. The embedded servers are started before the UI is
+        // constructed, so changing this value takes effect on extension reload.
         gbc.gridy = 5; gbc.gridx = 0; gbc.gridwidth = 2
-        content.add(JLabel("MCP Client Config").apply { font = font.deriveFont(Font.BOLD, 14f) }, gbc)
+        content.add(JLabel("Server Bind Address").apply { font = font.deriveFont(Font.BOLD, 14f) }, gbc)
         gbc.gridwidth = 1
 
-        val configArea = JTextArea(ConnectionInfo.clientConfigJson(authToken))
-        configArea.isEditable = false; configArea.font = Font("Monospaced", Font.PLAIN, 11)
-        configArea.lineWrap = true; configArea.wrapStyleWord = false; configArea.rows = 3
-        gbc.gridy = 6; gbc.gridx = 0; gbc.gridwidth = 2
-        content.add(configArea, gbc)
-        val copyConfigBtn = JButton("Copy Config")
-        copyConfigBtn.addActionListener { copyToClipboard(configArea.text) }
-        gbc.gridy = 7; gbc.gridx = 0; gbc.gridwidth = 1; gbc.weightx = 0.0
-        content.add(copyConfigBtn, gbc)
-        gbc.gridwidth = 1
+        gbc.gridy = 6; gbc.gridx = 0; gbc.weightx = 0.0
+        content.add(JLabel("Bind host:").apply { font = font.deriveFont(Font.BOLD) }, gbc)
+        val bindHostField = JTextField(bindHost, 18)
+        bindHostField.font = Font("Monospaced", Font.PLAIN, 12)
+        gbc.gridx = 1; gbc.weightx = 1.0
+        content.add(bindHostField, gbc)
+
+        val saveBindHostBtn = JButton("Save Bind Address")
+        saveBindHostBtn.addActionListener {
+            val value = bindHostField.text.trim().ifEmpty { "127.0.0.1" }
+            api.persistence().preferences().setString("mcp_bind_host", value)
+            JOptionPane.showMessageDialog(
+                panel,
+                "Bind address saved as $value.\nReload the BurpMCP-Ultra extension for it to take effect.",
+                "BurpMCP-Ultra",
+                JOptionPane.INFORMATION_MESSAGE
+            )
+        }
+        gbc.gridy = 7; gbc.gridx = 1; gbc.weightx = 0.0
+        content.add(saveBindHostBtn, gbc)
 
         gbc.gridy = 8; gbc.gridx = 0; gbc.gridwidth = 2
         content.add(JSeparator(), gbc); gbc.gridwidth = 1
 
-        // Live stats
+        // MCP config
         gbc.gridy = 9; gbc.gridx = 0; gbc.gridwidth = 2
+        content.add(JLabel("MCP Client Config").apply { font = font.deriveFont(Font.BOLD, 14f) }, gbc)
+        gbc.gridwidth = 1
+
+        val configArea = JTextArea(ConnectionInfo.clientConfigJson(authToken, host = bindHost))
+        configArea.isEditable = false; configArea.font = Font("Monospaced", Font.PLAIN, 11)
+        configArea.lineWrap = true; configArea.wrapStyleWord = false; configArea.rows = 3
+        gbc.gridy = 10; gbc.gridx = 0; gbc.gridwidth = 2
+        content.add(configArea, gbc)
+        val copyConfigBtn = JButton("Copy Config")
+        copyConfigBtn.addActionListener { copyToClipboard(configArea.text) }
+        gbc.gridy = 11; gbc.gridx = 0; gbc.gridwidth = 1; gbc.weightx = 0.0
+        content.add(copyConfigBtn, gbc)
+        gbc.gridwidth = 1
+
+        gbc.gridy = 12; gbc.gridx = 0; gbc.gridwidth = 2
+        content.add(JSeparator(), gbc); gbc.gridwidth = 1
+
+        // Live stats
+        gbc.gridy = 13; gbc.gridx = 0; gbc.gridwidth = 2
         content.add(JLabel("Live Statistics").apply { font = font.deriveFont(Font.BOLD, 14f) }, gbc)
         gbc.gridwidth = 1
 
-        serverUptimeLabel = JLabel("00:00:00"); addRow(10, "Uptime:", serverUptimeLabel)
-        serverToolCallsLabel = JLabel("0"); addRow(11, "Total MCP Tool Calls:", serverToolCallsLabel)
-        serverEventsLabel = JLabel("0"); addRow(12, "Event Buffer:", serverEventsLabel)
-        serverWsLabel = JLabel("0"); addRow(13, "WebSocket Connections:", serverWsLabel)
-        serverCollabLabel = JLabel("0"); addRow(14, "Collaborator Clients:", serverCollabLabel)
-        serverScanLabel = JLabel("0"); addRow(15, "Active Scan Tasks:", serverScanLabel)
+        serverUptimeLabel = JLabel("00:00:00"); addRow(14, "Uptime:", serverUptimeLabel)
+        serverToolCallsLabel = JLabel("0"); addRow(15, "Total MCP Tool Calls:", serverToolCallsLabel)
+        serverEventsLabel = JLabel("0"); addRow(16, "Event Buffer:", serverEventsLabel)
+        serverWsLabel = JLabel("0"); addRow(17, "WebSocket Connections:", serverWsLabel)
+        serverCollabLabel = JLabel("0"); addRow(18, "Collaborator Clients:", serverCollabLabel)
+        serverScanLabel = JLabel("0"); addRow(19, "Active Scan Tasks:", serverScanLabel)
 
         // Filler
-        gbc.gridy = 16; gbc.gridx = 0; gbc.weighty = 1.0; gbc.gridwidth = 2
+        gbc.gridy = 20; gbc.gridx = 0; gbc.weighty = 1.0; gbc.gridwidth = 2
         content.add(JLabel(), gbc)
 
         panel.add(JScrollPane(content), BorderLayout.CENTER)


### PR DESCRIPTION
## Summary by Sourcery

Add configurable server bind address support across MCP and dashboard transports, and propagate it through UI, URLs, and security configuration.

New Features:
- Introduce a configurable bind host/interface for MCP transport and dashboard servers, with fallback to 127.0.0.1 and preference storage.
- Expose the server bind address and host-specific connection URLs in the BurpMCP-Ultra UI, including an editable bind host field and MCP client config generation.

Enhancements:
- Generalize security and CORS configuration to support an explicit list of allowed hosts instead of hardcoded loopback addresses.
- Update connection URL helpers and dashboard HTML to be host-aware so all displayed endpoints reflect the configured bind address.
- Improve startup and logging messages to include the configured bind host for transport and dashboard servers.